### PR TITLE
Add custom.family parameter to remaining learners of the mboost family

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,11 @@ Authors@R:
       person(given = "Pierre",
              family = "Camilleri",
              role = "ctb",
-             email = "camilleri_pierre@hotmail.fr"))
+             email = "camilleri_pierre@hotmail.fr"),
+      person(given = "Javier",
+             family = "García",
+             role = "ctb",
+             email = "geshter@hotmail.com"))
 Description: Extra learners for use in mlr3.
 License: LGPL-3
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mlr3extralearners
 Title: Extra Learners For mlr3
-Version: 0.4.2
+Version: 0.4.3
 Authors@R:
     c(person(given = "Raphael",
              family = "Sonabend",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mlr3extralearners 0.4.3
+
+* Add support for custom families in all remaining mboost learners
+
 # mlr3extralearners 0.4.2
 
 * Fix broken partykit tests

--- a/R/learner_mboost_classif_gamboost.R
+++ b/R/learner_mboost_classif_gamboost.R
@@ -33,7 +33,8 @@ LearnerClassifGAMBoost = R6Class("LearnerClassifGAMBoost",
             special_vals = list(NULL), tags = "train"),
           ParamFct$new(
             id = "family", default = c("Binomial"),
-            levels = c("Binomial", "AdaExp", "AUC"), tags = "train"),
+            levels = c("Binomial", "AdaExp", "AUC", "custom"), tags = "train"),
+          ParamUty$new(id = "custom.family", tags = "train"),
           ParamFct$new(
             id = "link", default = "logit",
             levels = c("logit", "probit"), tags = "train"),
@@ -70,6 +71,11 @@ LearnerClassifGAMBoost = R6Class("LearnerClassifGAMBoost",
   private = list(
     .train = function(task) {
 
+      # parameter custom.family takes precedence over family
+      if (!is.null(self$param_set$values$custom.family)) {
+        self$param_set$values$family = "custom"
+      }
+
       # Default family in mboost::gamboost is not useable for twoclass
       if (is.null(self$param_set$values$family)) {
         self$param_set$values$family = "Binomial"
@@ -95,7 +101,8 @@ LearnerClassifGAMBoost = R6Class("LearnerClassifGAMBoost",
       pars_gamboost$family = switch(pars_gamboost$family,
         Binomial = mlr3misc::invoke(mboost::Binomial, .args = pars_binomial),
         AdaExp = mboost::AdaExp(),
-        AUC = mboost::AUC())
+        AUC = mboost::AUC(),
+        custom = pars$custom.family)
 
       # Predicted probabilities refer to the last factor level
       if (self$predict_type == "prob") {

--- a/R/learner_mboost_classif_glmboost.R
+++ b/R/learner_mboost_classif_glmboost.R
@@ -29,7 +29,8 @@ LearnerClassifGLMBoost = R6Class("LearnerClassifGLMBoost",
             tags = "train"),
           ParamFct$new(
             id = "family", default = c("Binomial"),
-            levels = c("Binomial", "AdaExp", "AUC"), tags = "train"),
+            levels = c("Binomial", "AdaExp", "AUC", "custom"), tags = "train"),
+          ParamUty$new(id = "custom.family", tags = "train"),
           ParamFct$new(
             id = "link", default = "logit",
             levels = c("logit", "probit"), tags = "train"),
@@ -68,6 +69,11 @@ LearnerClassifGLMBoost = R6Class("LearnerClassifGLMBoost",
   private = list(
     .train = function(task) {
 
+      # parameter custom.family takes precedence over family
+      if (!is.null(self$param_set$values$custom.family)) {
+        self$param_set$values$family = "custom"
+      }
+
       # Default family in mboost::glmboost is not useable for twoclass
       if (is.null(self$param_set$values$family)) {
         self$param_set$values = insert_named(
@@ -95,7 +101,8 @@ LearnerClassifGLMBoost = R6Class("LearnerClassifGLMBoost",
       pars_glmboost$family = switch(pars_glmboost$family,
         Binomial = invoke(mboost::Binomial, .args = pars_binomial),
         AdaExp = mboost::AdaExp(),
-        AUC = mboost::AUC())
+        AUC = mboost::AUC(),
+        custom = pars$custom.family)
 
       # Predicted probabilities refer to the last factor level
       if (self$predict_type == "prob") {

--- a/R/learner_mboost_regr_glmboost.R
+++ b/R/learner_mboost_regr_glmboost.R
@@ -69,7 +69,12 @@ LearnerRegrGLMBoost = R6Class("LearnerRegrGLMBoost",
   private = list(
     .train = function(task) {
 
-      # Set to default for switch
+      # parameter custom.family takes precedence over family
+      if (!is.null(self$param_set$values$custom.family)) {
+        self$param_set$values$family = "custom"
+      }
+
+      # Set to default for switch if no family is provided
       if (is.null(self$param_set$values$family)) {
         self$param_set$values = insert_named(
           self$param_set$values,

--- a/R/learner_mboost_surv_blackboost.R
+++ b/R/learner_mboost_surv_blackboost.R
@@ -102,6 +102,11 @@ LearnerSurvBlackBoost = R6Class("LearnerSurvBlackBoost",
   private = list(
     .train = function(task) {
 
+      # parameter custom.family takes precedence over family
+      if (!is.null(self$param_set$values$custom.family)) {
+        self$param_set$values$family = "custom"
+      }
+
       pars = self$param_set$get_values(tags = "train")
 
       if ("weights" %in% task$properties) {

--- a/R/learner_mboost_surv_gamboost.R
+++ b/R/learner_mboost_surv_gamboost.R
@@ -104,6 +104,11 @@ LearnerSurvGAMBoost = R6Class("LearnerSurvGAMBoost",
   private = list(
     .train = function(task) {
 
+      # parameter custom.family takes precedence over family
+      if (!is.null(self$param_set$values$custom.family)) {
+        self$param_set$values$family = "custom"
+      }
+
       pars = self$param_set$get_values(tags = "train")
 
       if ("weights" %in% task$properties) {

--- a/R/learner_mboost_surv_glmboost.R
+++ b/R/learner_mboost_surv_glmboost.R
@@ -107,6 +107,11 @@ LearnerSurvGLMBoost = R6Class("LearnerSurvGLMBoost",
   private = list(
     .train = function(task) {
 
+      # parameter custom.family takes precedence over family
+      if (!is.null(self$param_set$values$custom.family)) {
+        self$param_set$values$family = "custom"
+      }
+
       pars = self$param_set$get_values(tags = "train")
 
       saved_ctrl = mboost::boost_control()

--- a/R/learner_mboost_surv_mboost.R
+++ b/R/learner_mboost_surv_mboost.R
@@ -99,6 +99,11 @@ LearnerSurvMBoost = R6Class("LearnerSurvMBoost",
   private = list(
     .train = function(task) {
 
+      # parameter custom.family takes precedence over family
+      if (!is.null(self$param_set$values$custom.family)) {
+        self$param_set$values$family = "custom"
+      }
+
       pars = self$param_set$get_values(tags = "train")
 
       if ("weights" %in% task$properties) {

--- a/man/mlr_learners_classif.AdaBoostM1.Rd
+++ b/man/mlr_learners_classif.AdaBoostM1.Rd
@@ -5,7 +5,7 @@
 \alias{LearnerClassifAdaBoostM1}
 \title{Classification AdaBoostM1 Learner}
 \description{
-Calls \link[RWeka:Weka_classifier_meta]{RWeka::AdaBoostM1} from package \CRANpkg{RWeka}.
+Calls \link[RWeka:AdaBoostM1]{RWeka::AdaBoostM1} from package \CRANpkg{RWeka}.
 }
 \section{Dictionary}{
  This \link{Learner} can be instantiated via the

--- a/man/mlr_learners_classif.IBk.Rd
+++ b/man/mlr_learners_classif.IBk.Rd
@@ -5,7 +5,7 @@
 \alias{LearnerClassifIBk}
 \title{Classification IBk Learner}
 \description{
-Calls \link[RWeka:Weka_classifier_lazy]{RWeka::IBk} from package \CRANpkg{RWeka}.
+Calls \link[RWeka:IBk]{RWeka::IBk} from package \CRANpkg{RWeka}.
 }
 \section{Dictionary}{
  This \link{Learner} can be instantiated via the

--- a/man/mlr_learners_classif.J48.Rd
+++ b/man/mlr_learners_classif.J48.Rd
@@ -5,7 +5,7 @@
 \alias{LearnerClassifJ48}
 \title{Classification J48 Learner}
 \description{
-Calls \link[RWeka:Weka_classifier_trees]{RWeka::J48} from package \CRANpkg{RWeka}.
+Calls \link[RWeka:J48]{RWeka::J48} from package \CRANpkg{RWeka}.
 }
 \section{Dictionary}{
  This \link{Learner} can be instantiated via the

--- a/man/mlr_learners_classif.JRip.Rd
+++ b/man/mlr_learners_classif.JRip.Rd
@@ -5,7 +5,7 @@
 \alias{LearnerClassifJRip}
 \title{Classification JRip Learner}
 \description{
-Calls \link[RWeka:Weka_classifier_rules]{RWeka::JRip} from package \CRANpkg{RWeka}.
+Calls \link[RWeka:JRip]{RWeka::JRip} from package \CRANpkg{RWeka}.
 }
 \section{Dictionary}{
  This \link{Learner} can be instantiated via the

--- a/man/mlr_learners_classif.LMT.Rd
+++ b/man/mlr_learners_classif.LMT.Rd
@@ -5,7 +5,7 @@
 \alias{LearnerClassifLMT}
 \title{Classification Logistic Model Trees Learner}
 \description{
-Calls \link[RWeka:Weka_classifier_trees]{RWeka::LMT} from package \CRANpkg{RWeka}.
+Calls \link[RWeka:LMT]{RWeka::LMT} from package \CRANpkg{RWeka}.
 }
 \section{Dictionary}{
  This \link{Learner} can be instantiated via the

--- a/man/mlr_learners_classif.OneR.Rd
+++ b/man/mlr_learners_classif.OneR.Rd
@@ -5,7 +5,7 @@
 \alias{LearnerClassifOneR}
 \title{Classification OneR Learner}
 \description{
-Calls \link[RWeka:Weka_classifier_rules]{RWeka::OneR} from package \CRANpkg{RWeka}.
+Calls \link[RWeka:OneR]{RWeka::OneR} from package \CRANpkg{RWeka}.
 }
 \section{Dictionary}{
  This \link{Learner} can be instantiated via the

--- a/man/mlr_learners_classif.PART.Rd
+++ b/man/mlr_learners_classif.PART.Rd
@@ -5,7 +5,7 @@
 \alias{LearnerClassifPART}
 \title{Classification PART Learner}
 \description{
-Calls \link[RWeka:Weka_classifier_rules]{RWeka::PART} from package \CRANpkg{RWeka}.
+Calls \link[RWeka:PART]{RWeka::PART} from package \CRANpkg{RWeka}.
 }
 \section{Dictionary}{
  This \link{Learner} can be instantiated via the

--- a/man/mlr_learners_classif.lightgbm.Rd
+++ b/man/mlr_learners_classif.lightgbm.Rd
@@ -8,7 +8,7 @@
 Calls \link[lightgbm:lgb.train]{lightgbm::lgb.train} from package \CRANpkg{lightgbm}.
 }
 \details{
-For categorical features either first transform factor colums with \link[mlr3pipelines:mlr_pipeops_encode]{mlr3pipelines::PipeOpEncode}
+For categorical features either first transform factor colums with \link[mlr3pipelines:PipeOpEncode]{mlr3pipelines::PipeOpEncode}
 or convert the columns with \code{as.integer} and specify the categorical columns with the
 \code{categorical_feature} parameter.
 }

--- a/man/mlr_learners_dens.mixed.Rd
+++ b/man/mlr_learners_dens.mixed.Rd
@@ -5,7 +5,7 @@
 \alias{LearnerDensMixed}
 \title{Density Mixed Data Kernel Learner}
 \description{
-Calls \link[np:np.density]{np::npudens} from package \CRANpkg{np}.
+Calls \link[np:npudens]{np::npudens} from package \CRANpkg{np}.
 }
 \section{Dictionary}{
  This \link{Learner} can be instantiated via the

--- a/man/mlr_learners_regr.IBk.Rd
+++ b/man/mlr_learners_regr.IBk.Rd
@@ -5,7 +5,7 @@
 \alias{LearnerRegrIBk}
 \title{Regression IBk Learner}
 \description{
-Calls \link[RWeka:Weka_classifier_lazy]{RWeka::IBk} from package \CRANpkg{RWeka}.
+Calls \link[RWeka:IBk]{RWeka::IBk} from package \CRANpkg{RWeka}.
 }
 \section{Dictionary}{
  This \link{Learner} can be instantiated via the

--- a/man/mlr_learners_regr.M5Rules.Rd
+++ b/man/mlr_learners_regr.M5Rules.Rd
@@ -5,7 +5,7 @@
 \alias{LearnerRegrM5Rules}
 \title{Regression M5Rules Learner}
 \description{
-Calls \link[RWeka:Weka_classifier_rules]{RWeka::M5Rules} from package \CRANpkg{RWeka}.
+Calls \link[RWeka:M5Rules]{RWeka::M5Rules} from package \CRANpkg{RWeka}.
 }
 \section{Dictionary}{
  This \link{Learner} can be instantiated via the

--- a/man/mlr_learners_regr.lightgbm.Rd
+++ b/man/mlr_learners_regr.lightgbm.Rd
@@ -8,7 +8,7 @@
 Calls \link[lightgbm:lgb.train]{lightgbm::lgb.train} from package \CRANpkg{lightgbm}.
 }
 \details{
-For categorical features either first transform factor colums with \link[mlr3pipelines:mlr_pipeops_encode]{mlr3pipelines::PipeOpEncode}
+For categorical features either first transform factor colums with \link[mlr3pipelines:PipeOpEncode]{mlr3pipelines::PipeOpEncode}
 or convert the columns with \code{as.integer} and specify the categorical columns with the
 \code{categorical_feature} parameter.
 }


### PR DESCRIPTION
In addition, if custom.family is set, parameter family will be overriden to "custom"

# Updated Learner

This pull request updates Learners of the mboost family

### Reason for update

Make all members of the family accept a custom.family

## Dependencies

I have...

* [ ] Added more than one dependency to suggests - If ticked, explain why below.
* [ ] Added no dependencies to imports.
* [ ] Added dependencies to remotes - If ticked, explain why below.

## Tests

* [x] Learner autotest is passing locally.
* [x] Paramtest is passing locally.
* [ ] I have run `rcmdcheck::rcmdcheck` and there are no new NOTEs, WARNINGs, or ERRORs.

## Cleaning

I have run...

* [x] `devtools::document(roclets = c('rd', 'collate', 'namespace'))`

And 

* [x] Updated NEWS.md
* [x] Updated the package version (For patches (bug fixing, small added feature): add 1 to the 3rd number. For minor updates (new learner, new features): add 1 to the 2nd number). 

## Comments

I could not run rcmdcheck::rcmdcheck(). It requires further dependencies and devtools::install(".", dependencies=TRUE) could not run either (could not install dependency foreign).


