### PR TITLE
BREAKING CHANGE: lightgbm uses tasks test set for early stopping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # mlr3extralearners 0.6.0-9000
 
+* BREAKING CHANGE: lightgbm's early stopping mechanism now uses the task's test set.
+
 # mlr3extralearners 0.6.0
 
 * Feat: Added learner `LearnerClassifGlmer` (https://github.com/mlr-org/mlr3extralearners/issues/243)

--- a/R/learner_lightgbm_classif_lightgbm.R
+++ b/R/learner_lightgbm_classif_lightgbm.R
@@ -18,11 +18,6 @@
 #'   Additional parameter. If this parameter is set to `TRUE` (default), all factor and logical
 #'   columns are converted to integers and the parameter categorical_feature of lightgbm is set to
 #'   those columns.
-#' * `early_stopping_split`:
-#'  Additional parameter. Instead of providing the data that is used for early stopping explicitly,
-#'  the parameter `early_stopping_split` determines the proportion of the training data that is
-#'  used for early stopping. Here, stratification on the target variable is used if there is no
-#'  grouping variable, as one cannot simultaneously stratify and group.
 #' * `num_class`:
 #'  This parameter is automatically inferred for multiclass tasks and does not have to be set.
 #' @section Custom mlr3 defaults:
@@ -37,6 +32,8 @@
 #' * `objective`:
 #'   Depending if the task is binary / multiclass, the default is set to `"binary"` or
 #'   `"multiclasss"`.
+#' * `early_stopping`
+#'   Whether to use the test set for early stopping. Default is `TRUE`.
 #'
 #' @references
 #' `r format_bib("ke2017lightgbm")`
@@ -60,7 +57,8 @@ LearnerClassifLightGBM = R6Class("LearnerClassifLightGBM",
         record = p_lgl(default = TRUE, tags = "train"),
         eval_freq = p_int(default = 1L, lower = 1L, tags = "train"),
         early_stopping_rounds = p_int(lower = 1L, tags = "train"),
-        early_stopping_split = p_dbl(default = 0, lower = 0, upper = 1, tags = "train"),
+        # early_stopping is a custom parameter
+        early_stopping = p_lgl(default = FALSE, tags = "train"),
         callbacks = p_uty(tags = "train"),
         reset_data = p_lgl(default = FALSE, tags = "train"),
         categorical_feature = p_uty(default = "", tags = "train"),

--- a/R/learner_lightgbm_classif_lightgbm.R
+++ b/R/learner_lightgbm_classif_lightgbm.R
@@ -32,8 +32,9 @@
 #' * `objective`:
 #'   Depending if the task is binary / multiclass, the default is set to `"binary"` or
 #'   `"multiclasss"`.
+#' @section Custom mlr3 parameters:
 #' * `early_stopping`
-#'   Whether to use the test set for early stopping. Default is `TRUE`.
+#'   Whether to use the test set for early stopping. Default is `FALSE`.
 #'
 #' @references
 #' `r format_bib("ke2017lightgbm")`

--- a/R/learner_lightgbm_regr_lightgbm.R
+++ b/R/learner_lightgbm_regr_lightgbm.R
@@ -18,11 +18,6 @@
 #'   Additional parameter. If this parameter is set to `TRUE` (default), all factor and logical
 #'   columns are converted to integers and the parameter categorical_feature of lightgbm is set to
 #'   those columns.
-#' * `early_stopping_split`:
-#'  Additional parameter. Instead of providing the data that is used for early stopping explicitly,
-#'  the parameter `early_stopping_split` determines the proportion of the training data that is
-#'  used for early stopping. Here, stratification on the target variable is used if there is no
-#'  grouping variable, as one cannot simultaneously stratify and group.
 #' @section Custom mlr3 defaults:
 #' * `num_threads`:
 #'   * Actual default: 0L
@@ -57,7 +52,6 @@ LearnerRegrLightGBM = R6Class("LearnerRegrLightGBM",
         record = p_lgl(default = TRUE, tags = "train"),
         eval_freq = p_int(default = 1L, lower = 1L, tags = "train"),
         early_stopping_rounds = p_int(lower = 1L, tags = "train"),
-        early_stopping_split = p_dbl(default = 0, lower = 0, upper = 1, tags = "train"),
         callbacks = p_uty(tags = "train"),
         reset_data = p_lgl(default = FALSE, tags = "train"),
         categorical_feature = p_uty(default = "", tags = "train"),

--- a/R/learner_lightgbm_regr_lightgbm.R
+++ b/R/learner_lightgbm_regr_lightgbm.R
@@ -28,6 +28,10 @@
 #'   * Adjusted default: -1L
 #'   * Reason for change: Prevents accidental conflicts with mlr messaging system.
 #'
+#' @section Custom mlr3 parameters:
+#' * `early_stopping`
+#'   Whether to use the test set for early stopping. Default is `FALSE`.
+#'
 #' @references
 #' `r format_bib("ke2017lightgbm")`
 #'
@@ -52,6 +56,7 @@ LearnerRegrLightGBM = R6Class("LearnerRegrLightGBM",
         record = p_lgl(default = TRUE, tags = "train"),
         eval_freq = p_int(default = 1L, lower = 1L, tags = "train"),
         early_stopping_rounds = p_int(lower = 1L, tags = "train"),
+        early_stopping = p_lgl(default = FALSE, tags = "train"),
         callbacks = p_uty(tags = "train"),
         reset_data = p_lgl(default = FALSE, tags = "train"),
         categorical_feature = p_uty(default = "", tags = "train"),

--- a/tests/testthat/test_encode_data_lightgbm.R
+++ b/tests/testthat/test_encode_data_lightgbm.R
@@ -5,20 +5,6 @@ test_that("encode_data_lightgbm works for train", {
     x_lgl = sample(c(TRUE, FALSE), 100, TRUE)
   )
   task = as_task_regr(dat, target = "y")
-  # debugonce(encode_lightgbm)
-  encoding = encode_lightgbm_train(task)
-  X = encoding$X
-  y = encoding$y
-  categorical_feature = encoding$categorical_feature
-
-  X_expected = as.matrix(as.data.frame( # nolint
-    list(x_fct = as.integer(dat$x_fct), x_lgl = as.integer(dat$x_lgl))
-  ))
-
-  expect_true(all.equal(X_expected, X))
-
-  expect_true(all.equal(categorical_feature, c("x_fct", "x_lgl")))
-
   learner = lrn("regr.lightgbm")
   expect_error(learner$train(task), regexp = NA)
   learner$predict(task)
@@ -28,7 +14,6 @@ test_that("encode_data_lightgbm works for train", {
   expect_error(learner$predict_newdata(newdata), "There is a mismatch")
 
   expect_error(learner$predict(task), regexp = NA)
-  learner$param_set$values$early_stopping_split = 0.2
   expect_error(learner$train(task), regexp = NA)
   expect_error(learner$predict(task), regexp = NA)
 

--- a/tests/testthat/test_lightgbm_regr_lightgbm.R
+++ b/tests/testthat/test_lightgbm_regr_lightgbm.R
@@ -70,3 +70,12 @@ test_that("hotstarting works", {
   learner_hs$hotstart_stack = stack
   expect_true(is.null(get_private(learner_hs$model)$init_predictor))
 })
+
+test_that("early stopping works", {
+  learner = lrn("regr.lightgbm")
+  task = tsk("mtcars")
+  task$set_row_roles(1:10, "test")
+  task$set_row_roles(11:32, "use")
+  learner$train(task)
+
+})

--- a/tests/testthat/test_lightgbm_regr_lightgbm.R
+++ b/tests/testthat/test_lightgbm_regr_lightgbm.R
@@ -7,8 +7,9 @@ test_that("autotest", {
 })
 
 test_that("manual validation", {
-  learner = lrn("regr.lightgbm", early_stopping_rounds = 1, early_stopping_split = 0.1)
+  learner = lrn("regr.lightgbm", early_stopping_rounds = 1, early_stopping = TRUE)
   task = tsk("mtcars")
+  task$set_row_roles(1:10, "test")
   learner$train(task)
   expect_error(learner$train(task), regex = NA)
 })
@@ -71,11 +72,16 @@ test_that("hotstarting works", {
   expect_true(is.null(get_private(learner_hs$model)$init_predictor))
 })
 
+
 test_that("early stopping works", {
-  learner = lrn("regr.lightgbm")
+  learner = lrn("regr.lightgbm", early_stopping_rounds = 10, early_stopping = TRUE)
   task = tsk("mtcars")
   task$set_row_roles(1:10, "test")
-  task$set_row_roles(11:32, "use")
   learner$train(task)
 
+  dvalid = get_private(learner$model)$valid_sets
+  dtrain = get_private(learner$model)$train_set
+
+  expect_true(nrow(get_private(dvalid[[1L]])$raw_data) == 10)
+  expect_true(nrow(get_private(dtrain)$raw_data) == 22)
 })

--- a/tests/testthat/test_paramtest_lightgbm_classif_lightgbm.R
+++ b/tests/testthat/test_paramtest_lightgbm_classif_lightgbm.R
@@ -72,7 +72,7 @@ test_that("paramtest classif.lightgbm train", {
     "label_gain", # ranking
 
     # custom parameters
-    "early_stopping_split",
+    "early_stopping",
     "convert_categorical",
 
     # lgb.train
@@ -110,7 +110,8 @@ test_that("paramtest classif.lightgbm train", {
     "predcontrib", # shapely
     "header", # for prediction for text file
     "start_iteration", # alias for start_iteration_predict
-    "num_iteration" # alias for num_iteration_predict
+    "num_iteration", # alias for num_iteration_predict
+    "early_stopping" # custom parameter
   )
 
   paramtest = run_paramtest(learner, fun, exclude, tag = "predict")

--- a/tests/testthat/test_paramtest_lightgbm_regr_lightgbm.R
+++ b/tests/testthat/test_paramtest_lightgbm_regr_lightgbm.R
@@ -77,7 +77,7 @@ test_that("paramtest regr.lightgbm train", {
     "label_gain", # ranking
 
     # custom parameters
-    "early_stopping_split",
+    "early_stopping",
     "convert_categorical",
 
     # lgb.train
@@ -93,7 +93,7 @@ test_that("paramtest regr.lightgbm train", {
   expect_paramtest(paramtest)
 })
 
-test_that("paramtest regr.lightgbm train", {
+test_that("paramtest regr.lightgbm predict", {
   learner = lrn("regr.lightgbm")
   fun = list(lightgbm:::predict.lgb.Booster, x_predict)
   exclude = c(


### PR DESCRIPTION
Similar change as here: https://github.com/mlr-org/mlr3learners/commit/cb8162a4c85ef7183b6141d1519ba27c7cba5428  or  https://github.com/mlr-org/mlr3extralearners/commit/20272f119b7451675759408539b8d15e99a88dee

Context: 
Since this commit: https://github.com/mlr-org/mlr3/commit/435c9d13fae39ef3f3f6cf40cbfae6fc9d19a039, mlr3 Learners can access the test set while training, e.g. for early stopping or validation. 