### PR TITLE
fix: add catboost to DESCRIPTION

### DIFF
--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -14,6 +14,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron:  '0 4 * * 1'
 
 name: RCMD Check
 

--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -52,20 +52,6 @@ jobs:
         with:
           limit-access-to-actor: true
 
-      - name: Install catboost
-        run: |
-          version = jsonlite::fromJSON(
-            "https://api.github.com/repos/catboost/catboost/releases"
-          )$tag_name[1]
-          version = gsub("v", "", version)
-          os = as.character(Sys.info()["sysname"])
-          url = sprintf(
-            "https://github.com/catboost/catboost/releases/download/v%1$s/catboost-R-%2$s-%1$s.tgz",
-            version, os
-          )
-          remotes::install_url(url, INSTALL_opts = "--no-multiarch")
-        shell: Rscript {0}
-
       - name: Install Python
         run: |
           pak::pkg_install('rstudio/reticulate')

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -101,13 +101,12 @@ Suggests:
     xgboost
 Remotes:
     alan-turing-institute/distr6,
+    catboost/catboost/catboost/R-package@*release,
     binderh/CoxBoost,
-    catboost/catboost/catboost/R-package,
     mlr-org/mlr3proba,
     RaphaelS1/survivalmodels,
     xoopR/param6,
-    xoopR/set6,
-    ropensci/aorsf
+    xoopR/set6
 VignetteBuilder:
     knitr
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Suggests:
     actuar,
     apcluster,
     C50,
+    catboost,
     coin,
     CoxBoost,
     Cubist,
@@ -101,6 +102,7 @@ Suggests:
 Remotes:
     alan-turing-institute/distr6,
     binderh/CoxBoost,
+    catboost/catboost/catboost/R-package,
     mlr-org/mlr3proba,
     RaphaelS1/survivalmodels,
     xoopR/param6,

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,1 +1,0 @@
-future::plan("sequential")

--- a/tests/testthat/teardown.R
+++ b/tests/testthat/teardown.R
@@ -1,1 +1,0 @@
-future::plan(old_plan)


### PR DESCRIPTION
Because of a bug in pak, the package installation in the CI failed when catboost was in the DESCRIPTION, because of a bug in pak. With pak 4.0.0 that should be resolved.

https://github.com/r-lib/pak/issues/385
