### PR TITLE
fix: ranger did not receive `num.threads = 1` during `predict()`

### DIFF
--- a/R/learner_ranger_surv_ranger.R
+++ b/R/learner_ranger_surv_ranger.R
@@ -117,7 +117,7 @@ delayedAssign(
       .predict = function(task) {
         pv = self$param_set$get_values(tags = "predict")
         newdata = ordered_features(task, self)
-        prediction = predict(object = self$model, data = newdata)
+        prediction = invoke(predict, object = self$model, data = newdata, .args = pv)
         mlr3proba::.surv_return(times = prediction$unique.death.times, surv = prediction$survival)
       }
     )


### PR DESCRIPTION
Here https://github.com/mlr-org/mlr3extralearners/blob/0b3c766b025de30c1a1cafa026608269df557f13/R/learner_ranger_surv_ranger.R#L118-L120
the parameters were retrieved, but never actually passed to `predict()`.

This caused an issue in a benchmark setting where the prediction step caused a large spike in CPU load, and after asking Marvin he confirmed that prediction was multi-threaded in ranger, so this PR should fix that.