### PR TITLE
fix: exclude se.fit parameter from paramtest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -121,6 +121,5 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 NeedsCompilation: no
 Roxygen: list(markdown = TRUE, r6 = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.2.3.9000
 Config/Needs/website: rmarkdown
-

--- a/tests/testthat/test_paramtest_lme4_classif_glmer.R
+++ b/tests/testthat/test_paramtest_lme4_classif_glmer.R
@@ -33,7 +33,8 @@ test_that("regr.lmer predict", {
     "REForm", # alias of re.form
     "REform", # alias of re.form
     "terms", # unused
-    "type" # handled internally
+    "type", # handled internally
+    "se.fit" # not implemented
   )
 
   paramtest = run_paramtest(learner, fun, exclude, tag = "predict")

--- a/tests/testthat/test_paramtest_lme4_regr_lmer.R
+++ b/tests/testthat/test_paramtest_lme4_regr_lmer.R
@@ -32,7 +32,8 @@ test_that("regr.lmer predict", {
     "REForm", # alias of re.form
     "REform", # alias of re.form
     "terms", # unused
-    "type" # handled internally
+    "type", # handled internally
+    "se.fit" # not implemented
   )
 
   paramtest = run_paramtest(learner, fun, exclude, tag = "predict")


### PR DESCRIPTION
Please go the the `Preview` tab and select the appropriate sub-template:

* [New Learner](?expand=1&template=new_learner.md)
* [Other](?expand=1&template=other.md)
