### PR TITLE
fix: Remove mlr3 from Remotes: field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -114,8 +114,7 @@ Remotes:
     xoopR/distr6,
     xoopR/param6,
     xoopR/set6,
-    ropensci/aorsf,
-    mlr-org/mlr3
+    ropensci/aorsf
 VignetteBuilder:
     knitr
 Config/testthat/edition: 3


### PR DESCRIPTION
Otherwise it would be impossible to use CRAN-mlr3 with mlr3extralearners.