### PR TITLE
Fix parametric

### DIFF
--- a/R/learner_lightgbm_classif_lightgbm.R
+++ b/R/learner_lightgbm_classif_lightgbm.R
@@ -404,10 +404,11 @@ LearnerClassifLightGBM = R6Class("LearnerClassifLightGBM",
 
       if ("multiclass" %in% task$properties) {
         pred_mat = pred
-        colnames(pred_mat) = self$state$train_task$levels()[[self$state$train_task$target_names]]
+        labels = self$state$train_task$levels()[[self$state$train_task$target_names]]
+        colnames(pred_mat) = labels
         if (self$predict_type == "response") {
           which = apply(pred_mat, 1, which.max)
-          response = self$state$labels[which]
+          response = labels[which]
           pred_mat = NULL
         }
       } else {
@@ -450,7 +451,6 @@ LearnerClassifLightGBM = R6Class("LearnerClassifLightGBM",
       # set number of classes if multiclass and save label ordering
       if (pars_train$objective %in% c("multiclass", "multiclassova")) {
         pars_train$num_class = length(task$class_names)
-        self$state$labels = unique(task$truth())
       }
 
       if (pars_train$objective %in% c("multiclass", "multiclassova")) {

--- a/R/learner_survivalmodels_surv_parametric.R
+++ b/R/learner_survivalmodels_surv_parametric.R
@@ -21,13 +21,6 @@
 #' The parameter `ntime` allows to adjust the granularity of these time points
 #' to any number (e.g. `150`).
 #'
-#' @section Custom mlr3 parameters:
-#' - `discrete` determines the class of the returned survival probability
-#' distribution. If `FALSE`, vectorized continuous probability distributions are
-#' returned using [distr6::VectorDistribution], otherwise a [distr6::Matdist]
-#' object, which is faster for calculating survival measures that require a `distr`
-#' prediction type. Default option is `TRUE`.
-#'
 #' @template learner
 #' @templateVar id surv.parametric
 #' @template install_survivalmodels
@@ -96,12 +89,11 @@ LearnerSurvParametric = R6Class("LearnerSurvParametric",
         robust = p_lgl(default = FALSE, tags = "train"),
         score = p_lgl(default = FALSE, tags = "train"),
         cluster = p_uty(tags = "train"),
-        discrete = p_lgl(tags = c("required", "predict")),
         ntime = p_int(lower = 1, default = NULL, special_vals = list(NULL), tags = "predict"),
         round_time = p_int(default = 2, lower = 0, special_vals = list(FALSE), tags = "predict")
       )
 
-      ps$values = list(discrete = TRUE, dist = "weibull", form = "aft")
+      ps$values = list(dist = "weibull", form = "aft")
 
       super$initialize(
         id = "surv.parametric",
@@ -144,7 +136,7 @@ LearnerSurvParametric = R6Class("LearnerSurvParametric",
         self$model,
         newdata = newdata,
         times = times,
-        distr6 = !pv$discrete,
+        distr6 = FALSE,
         type = "all",
         .args = pv
       )

--- a/man/mlr_learners_dens.mixed.Rd
+++ b/man/mlr_learners_dens.mixed.Rd
@@ -6,7 +6,7 @@
 \title{Density Mixed Data Kernel Learner}
 \description{
 Density estimator for discrete and continuous variables.
-Calls \code{\link[np:npudens]{np::npudens()}} from \CRANpkg{np}.
+Calls \code{\link[np:np.density]{np::npudens()}} from \CRANpkg{np}.
 }
 \section{Dictionary}{
 

--- a/man/mlr_learners_surv.bart.Rd
+++ b/man/mlr_learners_surv.bart.Rd
@@ -6,7 +6,7 @@
 \title{Survival Bayesian Additive Regression Trees Learner}
 \description{
 Fits a Bayesian Additive Regression Trees (BART) learner to right-censored
-survival data. Calls \code{\link[BART:mc.surv.bart]{BART::mc.surv.bart()}} from \CRANpkg{BART}.
+survival data. Calls \code{\link[BART:surv.bart]{BART::mc.surv.bart()}} from \CRANpkg{BART}.
 }
 \section{Prediction types}{
 

--- a/man/mlr_learners_surv.parametric.Rd
+++ b/man/mlr_learners_surv.parametric.Rd
@@ -64,17 +64,6 @@ to any number (e.g. \code{150}).
 }
 }
 
-\section{Custom mlr3 parameters}{
-
-\itemize{
-\item \code{discrete} determines the class of the returned survival probability
-distribution. If \code{FALSE}, vectorized continuous probability distributions are
-returned using \link[distr6:VectorDistribution]{distr6::VectorDistribution}, otherwise a \link[distr6:Matdist]{distr6::Matdist}
-object, which is faster for calculating survival measures that require a \code{distr}
-prediction type. Default option is \code{TRUE}.
-}
-}
-
 \section{Dictionary}{
 
 This \link[mlr3:Learner]{Learner} can be instantiated via \link[mlr3:mlr_sugar]{lrn()}:
@@ -110,7 +99,6 @@ This \link[mlr3:Learner]{Learner} can be instantiated via \link[mlr3:mlr_sugar]{
    robust \tab logical \tab FALSE \tab TRUE, FALSE \tab - \cr
    score \tab logical \tab FALSE \tab TRUE, FALSE \tab - \cr
    cluster \tab untyped \tab - \tab  \tab - \cr
-   discrete \tab logical \tab - \tab TRUE, FALSE \tab - \cr
    ntime \tab integer \tab NULL \tab  \tab \eqn{[1, \infty)}{[1, Inf)} \cr
    round_time \tab integer \tab 2 \tab  \tab \eqn{[0, \infty)}{[0, Inf)} \cr
 }

--- a/tests/testthat/test_paramtest_survivalmodels_surv_parametric.R
+++ b/tests/testthat/test_paramtest_survivalmodels_surv_parametric.R
@@ -36,8 +36,7 @@ test_that("paramtest surv.parametric predict", {
     "form", # handled internally
     "times", # handled internally
     "ntime", # handled internally
-    "round_time", # handled internally
-    "discrete"
+    "round_time" # handled internally
   )
 
   paramtest = run_paramtest(learner, fun = fun, exclude, tag = "predict")

--- a/tests/testthat/test_survivalmodels_surv_parametric.R
+++ b/tests/testthat/test_survivalmodels_surv_parametric.R
@@ -8,7 +8,7 @@ test_that("autotest aft", {
 
 test_that("autotest ph", {
   set.seed(1)
-  learner = lrn("surv.parametric", form = "ph", discrete = FALSE)
+  learner = lrn("surv.parametric", form = "ph")
   expect_learner(learner)
   result = run_autotest(learner, check_replicable = FALSE, exclude = "utf8_feature_names")
   expect_true(result, info = result$error)
@@ -22,9 +22,8 @@ test_that("autotest po", {
   expect_true(result, info = result$error)
 })
 
-task = tsk("lung")
-
 test_that("time points for prediction", {
+  task = tsk("lung")
   learner = lrn("surv.parametric")
   p = learner$train(task)$predict(task)
   times = as.integer(colnames(p$data$distr))
@@ -45,167 +44,48 @@ test_that("time points for prediction", {
   expect_equal(length(times), 50)
 })
 
-test_that("manualtest - aft", {
-  learner = lrn("surv.parametric", dist = "weibull", form = "aft", discrete = FALSE)
-  expect_silent(learner$train(task))
-  p = learner$predict(task)
-  expect_prediction_surv(p)
-  expect_equal(-p$lp, predict(learner$model$model, type = "lp"))
-  expect_equal(p$distr[1]$survival(predict(
-    learner$model$model, type = "quantile", p = c(0.2, 0.8)
-  )[1, ]), c(0.8, 0.2))
-  expect_equal(p$distr[10]$cdf(predict(
-    learner$model$model, type = "quantile", p = seq.int(0, 1, 0.1)
-  )[10, ]),
-  seq.int(0, 1, 0.1))
-
-  learner = lrn("surv.parametric", dist = "lognormal", form = "aft", discrete = FALSE)$train(task)
-  p = learner$predict(task)
-  expect_equal(p$distr[15]$cdf(predict(
-    learner$model$model, type = "quantile", p = seq.int(0, 1, 0.1)
-  )[15, ]), seq.int(0, 1, 0.1))
-})
-
 test_that("missing", {
   learner = lrn("surv.parametric")
   learner$train(task)
   expect_error(learner$predict(lung_missings))
 })
 
-test_that("quantile type", {
-  learner = lrn("surv.parametric", dist = "weibull", form = "aft", discrete = FALSE)$train(task)
-  p = lrn("surv.parametric", dist = "weibull", form = "aft", discrete = FALSE)$train(task)$predict(task)
-  quantile = p$distr$quantile(c(0.2, 0.8))
-  expect_equal(matrix(t(quantile), ncol = 2),
-               predict(learner$model$model, type = "quantile", p = c(0.2, 0.8)))
-  quantile = p$distr$quantile(0.5)
-  expect_equal(unlist(p$distr$cdf(quantile), use.names = FALSE), rep(0.5, task$nrow))
+test_that("'form' affects survival prediction", {
+  task = tsk("lung")
 
-  p = lrn("surv.parametric", dist = "weibull", form = "ph", discrete = FALSE)$train(task)$predict(task)
-  quantile = p$distr$quantile(0.5)
-  expect_equal(unlist(p$distr$cdf(quantile), use.names = FALSE), rep(0.5, task$nrow))
+  # aft
+  p = lrn("surv.parametric", form = "aft")$train(task)$predict(task)
+  expect_true(inherits(p$distr, "Matdist"))
+  surv_aft = p$distr$survival(task$unique_times())
+  expect_matrix(surv_aft, nrows = length(task$unique_times()), ncols = task$nrow,
+                any.missing = FALSE) # [times x obs]
 
-  p = lrn("surv.parametric", dist = "weibull", form = "po", discrete = FALSE)$train(task)$predict(task)
-  quantile = p$distr$quantile(0.5)
-  expect_equal(unlist(p$distr$cdf(quantile), use.names = FALSE), rep(0.5, task$nrow))
-})
+  # tobit
+  p = lrn("surv.parametric", form = "tobit")$train(task)$predict(task)
+  expect_true(inherits(p$distr, "Matdist"))
+  surv_tobit = p$distr$survival(task$unique_times())
+  expect_matrix(surv_tobit, nrows = length(task$unique_times()), ncols = task$nrow,
+                any.missing = FALSE) # [times x obs]
 
-test_that("quantile dist", {
-  learner = lrn("surv.parametric", dist = "weibull", form = "aft", discrete = FALSE)$train(task)
-  p = learner$predict(task)
-  quantile = p$distr$quantile(c(0.2, 0.8))
-  expect_equal(matrix(t(quantile), ncol = 2),
-               predict(learner$model$model, type = "quantile", p = c(0.2, 0.8)))
+  # ph
+  p = lrn("surv.parametric", form = "ph")$train(task)$predict(task)
+  expect_true(inherits(p$distr, "Matdist"))
+  surv_ph = p$distr$survival(task$unique_times())
+  expect_matrix(surv_ph, nrows = length(task$unique_times()), ncols = task$nrow,
+                any.missing = FALSE) # [times x obs]
 
-  learner = lrn("surv.parametric", dist = "exponential", form = "aft", discrete = FALSE)$train(task)
-  p = learner$predict(task)
-  quantile = p$distr$quantile(c(0.2, 0.8))
-  expect_equal(matrix(t(quantile), ncol = 2),
-               predict(learner$model$model, type = "quantile", p = c(0.2, 0.8)))
+  # po
+  p = lrn("surv.parametric", form = "po")$train(task)$predict(task)
+  expect_true(inherits(p$distr, "Matdist"))
+  surv_po = p$distr$survival(task$unique_times())
+  expect_matrix(surv_po, nrows = length(task$unique_times()), ncols = task$nrow,
+                any.missing = FALSE) # [times x obs]
 
-  learner = lrn("surv.parametric", dist = "gaussian", form = "tobit", discrete = FALSE)$train(task)
-  p = learner$predict(task)
-  quantile = p$distr$quantile(c(0.2, 0.8))
-  expect_equal(matrix(t(quantile), ncol = 2),
-               predict(learner$model$model, type = "quantile", p = c(0.2, 0.8)))
-
-  learner = lrn("surv.parametric", dist = "lognormal", discrete = FALSE)$train(task)
-  p = learner$predict(task)
-  quantile = p$distr$quantile(c(0.2, 0.8))
-  expect_equal(matrix(t(quantile), ncol = 2),
-               predict(learner$model$model, type = "quantile", p = c(0.2, 0.8)))
-})
-
-test_that("cdf dist", {
-  row_ids = 1:10
-  value = length(row_ids)
-
-  learner = lrn("surv.parametric", dist = "weibull", form = "aft", discrete = FALSE)$train(task)
-  p = learner$predict(task, row_ids = row_ids)
-  cdf = predict(learner$model$model, type = "quantile", p = c(0.2, 0.8))[row_ids, ]
-  expect_equal(unname(as.matrix(p$distr$cdf(data = t(cdf)))),
-               matrix(c(rep(0.2, value), rep(0.8, value)), byrow = TRUE, nrow = 2))
-
-  learner = lrn("surv.parametric", dist = "exponential", form = "aft", discrete = FALSE)$train(task)
-  p = learner$predict(task, row_ids = row_ids)
-  cdf = predict(learner$model$model, type = "quantile", p = c(0.2, 0.8))[row_ids, ]
-  expect_equal(unname(as.matrix(p$distr$cdf(data = t(cdf)))),
-               matrix(c(rep(0.2, value), rep(0.8, value)), byrow = TRUE, nrow = 2))
-
-  learner = lrn("surv.parametric", dist = "gaussian", form = "tobit", discrete = FALSE)$train(task)
-  p = learner$predict(task, row_ids = row_ids)
-  cdf = predict(learner$model$model, type = "quantile", p = c(0.2, 0.8))[row_ids, ]
-  expect_equal(unname(as.matrix(p$distr$cdf(data = t(cdf)))),
-               matrix(c(rep(0.2, value), rep(0.8, value)), byrow = TRUE, nrow = 2))
-
-  learner = lrn("surv.parametric", dist = "lognormal", discrete = FALSE)$train(task)
-  p = learner$predict(task, row_ids = row_ids)
-  cdf = predict(learner$model$model, type = "quantile", p = c(0.2, 0.8))[row_ids, ]
-  expect_equal(unname(as.matrix(p$distr$cdf(data = t(cdf)))),
-               matrix(c(rep(0.2, value), rep(0.8, value)), byrow = TRUE, nrow = 2))
-})
-
-test_that("loglogistic", {
-  row_ids = 1:10
-  value = length(row_ids)
-
-  learner = lrn("surv.parametric", dist = "loglogistic", discrete = FALSE)$train(task)
-  p = learner$predict(task, row_ids = row_ids)
-  quantile = p$distr$quantile(c(0.2, 0.8))
-  expect_equal(matrix(t(quantile), ncol = 2),
-               predict(learner$model$model, type = "quantile", p = c(0.2, 0.8))[row_ids, ])
-
-
-  learner = lrn("surv.parametric", dist = "loglogistic", discrete = FALSE)$train(task)
-  p = learner$predict(task, row_ids = row_ids)
-  cdf = predict(learner$model$model, type = "quantile", p = c(0.2, 0.8))[row_ids, ]
-  expect_equal(unname(as.matrix(p$distr$cdf(data = t(cdf)))),
-               matrix(c(rep(0.2, value), rep(0.8, value)), byrow = TRUE, nrow = 2))
-})
-
-task = tsk("rats")
-task$filter(sample(task$nrow, 100))
-
-test_that("discrete - aft", {
-  p_cont = lrn("surv.parametric", discrete = FALSE)$train(task)$predict(task)
-  p_disc = lrn("surv.parametric", discrete = TRUE)$train(task)$predict(task)
-  expect_equal(p_cont$lp, p_disc$lp)
-  expect_true(inherits(p_disc$distr, "Matdist"))
-  s_cont = as.matrix(p_cont$distr$survival(task$unique_times()))
-  dimnames(s_cont) = list(task$unique_times(), NULL)
-  s_disc = p_disc$distr$survival(task$unique_times())
-  expect_equal(s_cont, s_disc)
-})
-
-test_that("discrete - tobit", {
-  p_cont = lrn("surv.parametric", discrete = FALSE, form = "tobit")$train(task)$predict(task)
-  p_disc = lrn("surv.parametric", discrete = TRUE, form = "tobit")$train(task)$predict(task)
-  expect_equal(p_cont$lp, p_disc$lp)
-  expect_true(inherits(p_disc$distr, "Matdist"))
-  s_cont = as.matrix(p_cont$distr$survival(task$unique_times()))
-  dimnames(s_cont) = list(task$unique_times(), NULL)
-  s_disc = p_disc$distr$survival(task$unique_times())
-  expect_equal(s_cont, s_disc)
-})
-
-test_that("discrete - ph", {
-  p_cont = lrn("surv.parametric", discrete = FALSE, form = "ph")$train(task)$predict(task)
-  p_disc = lrn("surv.parametric", discrete = TRUE, form = "ph")$train(task)$predict(task)
-  expect_equal(p_cont$lp, p_disc$lp)
-  expect_true(inherits(p_disc$distr, "Matdist"))
-  s_cont = as.matrix(p_cont$distr$survival(task$unique_times()))
-  dimnames(s_cont) = list(task$unique_times(), NULL)
-  s_disc = p_disc$distr$survival(task$unique_times())
-  expect_equal(s_cont, s_disc)
-})
-
-test_that("discrete - po", {
-  p_cont = lrn("surv.parametric", discrete = FALSE, form = "po")$train(task)$predict(task)
-  p_disc = lrn("surv.parametric", discrete = TRUE, form = "po")$train(task)$predict(task)
-  expect_equal(p_cont$lp, p_disc$lp)
-  expect_true(inherits(p_disc$distr, "Matdist"))
-  s_cont = as.matrix(p_cont$distr$survival(task$unique_times()))
-  dimnames(s_cont) = list(task$unique_times(), NULL)
-  s_disc = p_disc$distr$survival(task$unique_times())
-  expect_equal(s_cont, s_disc)
+  # predicted survival matrices are different
+  assert_true(any(surv_aft != surv_tobit))
+  assert_true(any(surv_aft != surv_ph))
+  assert_true(any(surv_aft != surv_po))
+  assert_true(any(surv_tobit != surv_ph))
+  assert_true(any(surv_tobit != surv_po))
+  assert_true(any(surv_ph != surv_po))
 })

--- a/tests/testthat/test_survivalmodels_surv_parametric.R
+++ b/tests/testthat/test_survivalmodels_surv_parametric.R
@@ -22,8 +22,9 @@ test_that("autotest po", {
   expect_true(result, info = result$error)
 })
 
+task = tsk("lung")
+
 test_that("time points for prediction", {
-  task = tsk("lung")
   learner = lrn("surv.parametric")
   p = learner$train(task)$predict(task)
   times = as.integer(colnames(p$data$distr))
@@ -51,8 +52,6 @@ test_that("missing", {
 })
 
 test_that("'form' affects survival prediction", {
-  task = tsk("lung")
-
   # aft
   p = lrn("surv.parametric", form = "aft")$train(task)$predict(task)
   expect_true(inherits(p$distr, "Matdist"))


### PR DESCRIPTION
Remove `discrete = FALSE` option, only return discrete survival predictions, works with `mlr3proba` v0.8.1