### PR TITLE
fix: declare fully-bayesian python deps for botorch learner

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# mlr3extralearners (development version)
+
+## Other
+
+* `regr.botorch_fullybayesian` now declares its `numpyro`, `jax`, and `jaxlib` Python dependencies so they are installed automatically.
+
 # mlr3extralearners 1.5.2
 
 ## Other

--- a/R/learner_botorch_regr_fullybayesian.R
+++ b/R/learner_botorch_regr_fullybayesian.R
@@ -71,7 +71,7 @@ LearnerRegrBotorchFullyBayesian = R6Class("LearnerRegrBotorchFullyBayesian",
   ),
   private = list(
     .train = function(task) {
-      assert_python_packages(c("torch", "botorch", "gpytorch"))
+      assert_python_packages(c("torch", "botorch", "gpytorch", "numpyro", "jax", "jaxlib"))
       torch = reticulate::import("torch")
       botorch = reticulate::import("botorch")
 
@@ -121,7 +121,7 @@ LearnerRegrBotorchFullyBayesian = R6Class("LearnerRegrBotorchFullyBayesian",
     },
 
     .predict = function(task) {
-      assert_python_packages(c("torch", "botorch", "gpytorch"))
+      assert_python_packages(c("torch", "botorch", "gpytorch", "numpyro", "jax", "jaxlib"))
       torch = reticulate::import("torch")
       pars = self$param_set$get_values(tags = "predict")
 


### PR DESCRIPTION
## Problem

CI's `R CMD check` fails in `test_botorch_regr_fullybayesian.R` with:

> ImportError: BoTorch's fully Bayesian models require JAX, jaxlib, and NumPyro, which are optional dependencies.

`regr.botorch_fullybayesian` only declared `torch`, `botorch`, and `gpytorch` via `assert_python_packages()`, so the fully-Bayesian backend's optional deps were never installed into reticulate's ephemeral environment. The missing import caused a clean error on one test and hard `callr` subprocess crashes on the others.

## Fix

Add `numpyro`, `jax`, and `jaxlib` to the `assert_python_packages()` calls in both `.train()` and `.predict()`. Since the helper routes through `reticulate::py_require()`, these are now installed automatically.

Verified locally: `py_require()` installs and `py_module_available()` reports all three importable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)