### PR TITLE
docs: redocument with roxygen2 8.0.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -157,4 +157,4 @@ Config/testthat/parallel: false
 Encoding: UTF-8
 NeedsCompilation: no
 Roxygen: list(markdown = TRUE, r6 = TRUE)
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.0.0.9000


### PR DESCRIPTION
Regenerate man pages and NAMESPACE with `devtools::document()` using roxygen2 8.0.0.9000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)